### PR TITLE
fix: remove unneeded link targets and one included header

### DIFF
--- a/src/geocad/CMakeLists.txt
+++ b/src/geocad/CMakeLists.txt
@@ -3,7 +3,7 @@ if(NOT USE_GEOCAD)
   return()
 endif()
 
-find_package(ROOT REQUIRED COMPONENTS Geom GenVector MathCore)
+find_package(ROOT REQUIRED COMPONENTS Geom)
 find_package(OpenCASCADE REQUIRED)
 
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -4,20 +4,21 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 cmake_policy(SET CMP0074 NEW)
 
 include(GNUInstallDirs)
+
+# Required dependencies
 find_package(fmt REQUIRED)
-find_package(spdlog REQUIRED)
-find_package(DD4hep REQUIRED COMPONENTS DDCore DDG4 )
-find_package(ROOT REQUIRED COMPONENTS Geom GenVector MathCore)
+find_package(DD4hep REQUIRED COMPONENTS DDCore DDRec)
+find_package(ROOT REQUIRED COMPONENTS Geom GenVector Gpad Hist MathCore)
 include(${ROOT_USE_FILE})
+
+# Optional dependencies
+find_package(spdlog)
 
 # ------------------------------------
 # npdet_fields
 # ------------------------------------
 set(exe_name npdet_fields)
 add_executable(${exe_name} src/${exe_name}.cxx src/settings.cxx)
-target_link_libraries(${exe_name}
-  PUBLIC DD4hep::DDCore
-  )
 target_include_directories(${exe_name}
   PRIVATE include )
 target_compile_features(${exe_name}
@@ -26,7 +27,7 @@ target_compile_features(${exe_name}
   PUBLIC cxx_trailing_return_types
   PRIVATE cxx_variadic_templates )
 target_link_libraries(${exe_name}
-  PUBLIC DD4hep::DDCore DD4hep::DDG4 ROOT::Core ROOT::Hist ROOT::GenVector ROOT::Gpad)
+  PUBLIC DD4hep::DDCore ROOT::Core ROOT::Hist ROOT::Gpad)
 install(TARGETS ${exe_name}
   EXPORT NPDetTargets
   RUNTIME DESTINATION bin )
@@ -36,7 +37,7 @@ install(TARGETS ${exe_name}
 # npdet_to_step
 # ------------------------------------
 # npdet_to_step needs the (formerly part of ROOT) GeoCad library
-if(USE_GEOCAD)
+if(TARGET GeoCad)
   set(exe_name npdet_to_step)
   add_executable(${exe_name} src/${exe_name}.cxx src/settings.cxx)
   target_include_directories(${exe_name}
@@ -47,30 +48,36 @@ if(USE_GEOCAD)
     PRIVATE cxx_variadic_templates
     PRIVATE cxx_std_17)
   target_link_libraries(${exe_name}
-    PUBLIC DD4hep::DDCore DD4hep::DDG4 ROOT::Core ROOT::Hist ROOT::GenVector ROOT::Gpad GeoCad)
+    PUBLIC DD4hep::DDCore ROOT::Core GeoCad)
   install(TARGETS ${exe_name}
     EXPORT NPDetTargets
     RUNTIME DESTINATION bin )
+else()
+  message(WARNING "npdet_to_step will not be built")
 endif()
 
 # ------------------------------------
 # npdet_to_teve
 # ------------------------------------
-set(exe_name npdet_to_teve)
-add_executable(${exe_name} src/${exe_name}.cxx src/settings.cxx)
-target_include_directories(${exe_name}
-  PRIVATE include )
-target_compile_features(${exe_name}
-  PUBLIC cxx_std_17
-  PUBLIC cxx_auto_type
-  PUBLIC cxx_trailing_return_types
-  PRIVATE cxx_variadic_templates
-  )
-target_link_libraries(${exe_name}
-  PUBLIC DD4hep::DDCore DD4hep::DDG4 ROOT::Core ROOT::Hist ROOT::GenVector ROOT::Eve ROOT::Gpad ROOT::Imt)
-install(TARGETS ${exe_name}
-  EXPORT NPDetTargets
-  RUNTIME DESTINATION bin )
+if(TARGET ROOT::Eve)
+  set(exe_name npdet_to_teve)
+  add_executable(${exe_name} src/${exe_name}.cxx src/settings.cxx)
+  target_include_directories(${exe_name}
+    PRIVATE include )
+  target_compile_features(${exe_name}
+    PUBLIC cxx_std_17
+    PUBLIC cxx_auto_type
+    PUBLIC cxx_trailing_return_types
+    PRIVATE cxx_variadic_templates
+    )
+  target_link_libraries(${exe_name}
+    PUBLIC DD4hep::DDCore ROOT::Core ROOT::Eve ROOT::Imt)
+  install(TARGETS ${exe_name}
+    EXPORT NPDetTargets
+    RUNTIME DESTINATION bin )
+else()
+  message(WARNING "npdet_to_teve will not be built")
+endif()
 
 # ------------------------------------
 # npdet_mat_budget
@@ -86,9 +93,7 @@ target_compile_features(${exe_name}
   PRIVATE cxx_variadic_templates
   )
 target_link_libraries(${exe_name}
-  PUBLIC DD4hep::DDRec DD4hep::DDCore DD4hep::DDG4 ROOT::Core ROOT::Hist ROOT::GenVector ROOT::Eve ROOT::Gpad ROOT::Imt
-  fmt::fmt
-  spdlog::spdlog)
+  PUBLIC DD4hep::DDCore DD4hep::DDRec ROOT::Core fmt::fmt)
 install(TARGETS ${exe_name}
   EXPORT NPDetTargets
   RUNTIME DESTINATION bin )
@@ -96,7 +101,7 @@ install(TARGETS ${exe_name}
 # ------------------------------------
 # dd_web_display
 # ------------------------------------
-if (ROOT_http_FOUND)
+if(TARGET ROOT::RHTTP)
  set(exe_name dd_web_display)
   add_executable(${exe_name} src/${exe_name}.cxx src/settings.cxx)
   target_include_directories(${exe_name}
@@ -108,48 +113,28 @@ if (ROOT_http_FOUND)
     PUBLIC cxx_std_17
     )
   target_link_libraries(${exe_name}
-    PUBLIC DD4hep::DDCore DD4hep::DDG4 ROOT::Core ROOT::Hist ROOT::GenVector ROOT::Eve ROOT::Gpad ROOT::Imt ROOT::RHTTP ROOT::Net fmt::fmt spdlog::spdlog)
+    PUBLIC DD4hep::DDCore ROOT::Core ROOT::RHTTP ROOT::Net fmt::fmt spdlog::spdlog)
   install(TARGETS ${exe_name}
     EXPORT NPDetTargets
     RUNTIME DESTINATION bin )
-else(ROOT_http_FOUND)
+else()
   message(WARNING "dd_web_display will not be built")
-endif(ROOT_http_FOUND)
+endif()
 
 # ------------------------------------
 # npdet_info
 # ------------------------------------
-if (ROOT_http_FOUND)
-  set(exe_name npdet_info)
-  add_executable(${exe_name} src/${exe_name}.cxx )
-  target_include_directories(${exe_name}
-    PRIVATE include )
-  target_compile_features(${exe_name}
-    PUBLIC cxx_auto_type
-    PUBLIC cxx_trailing_return_types
-    PRIVATE cxx_variadic_templates
-    PUBLIC cxx_std_17)
-  target_link_libraries(${exe_name}
-    PUBLIC DD4hep::DDCore DD4hep::DDG4 ROOT::Core ROOT::Hist ROOT::GenVector ROOT::Eve ROOT::Gpad ROOT::Imt ROOT::RHTTP ROOT::Net
-    fmt::fmt
-    spdlog::spdlog)
-  install(TARGETS ${exe_name}
-    EXPORT NPDetTargets
-    RUNTIME DESTINATION bin )
-else(ROOT_http_FOUND)
-  message(WARNING "npdet_info will not be built")
-endif()
-
-# ----------------------------------------------
-# Tests
-## InitialState
-#set(test_name simple)
-#add_executable(${test_name} tests/${test_name}.cxx src/settings.cxx)
-##target_include_directories(${test_name} PUBLIC
-##  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core>
-##  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-##  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
-##  )
-#target_link_libraries(${test_name} Catch2::Catch2)
-#add_test(NAME ${test_name} COMMAND ${test_name} -r junit -o test_result_${test_name}.xml
-#  WORKING_DIRECTORY ${CMAKE_BINARY_DIR} )
+set(exe_name npdet_info)
+add_executable(${exe_name} src/${exe_name}.cxx )
+target_include_directories(${exe_name}
+  PRIVATE include )
+target_compile_features(${exe_name}
+  PUBLIC cxx_auto_type
+  PUBLIC cxx_trailing_return_types
+  PRIVATE cxx_variadic_templates
+  PUBLIC cxx_std_17)
+target_link_libraries(${exe_name}
+  PUBLIC DD4hep::DDCore ROOT::Core ROOT::Hist ROOT::GenVector fmt::fmt)
+install(TARGETS ${exe_name}
+  EXPORT NPDetTargets
+  RUNTIME DESTINATION bin )

--- a/src/tools/src/npdet_fields.cxx
+++ b/src/tools/src/npdet_fields.cxx
@@ -20,7 +20,6 @@
 
 #include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/Detector.h"
-#include "DDG4/Geant4Data.h"
 #include "DDRec/CellIDPositionConverter.h"
 #include "DDRec/Surface.h"
 #include "DDRec/SurfaceManager.h"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Removes unneeded link targets so we can more specifically build all we have found support for and avoid failing if components are not available.

Fixes #10.