### PR TITLE
fix: don't require name in `npdet_to_step part`

### DIFF
--- a/src/tools/src/npdet_to_step.cxx
+++ b/src/tools/src/npdet_to_step.cxx
@@ -89,8 +89,9 @@ settings cmdline_settings(int argc, char* argv[])
   auto partMode = "part mode:" % repeatable(
     command("part").set(s.selected,mode::part) % "Select only the first level nodes by name", 
     repeatable(
-      option("-l","--level").set(s.level_set) & value("level",s.part_level) % "Maximum level navigated to for part",
-      value("name")([&](const std::string& p)
+      option("-l","--level").set(s.level_set)
+      & value("level",s.part_level) % "Maximum level navigated to for part"
+      & value("name")([&](const std::string& p)
                     {
                       s.part_name = p;
                       if(!s.level_set) { s.part_level = -1; }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR changes the `npdet_to_step` options from:
```
npdet_to_step (part ([-l <level>] <name>)...)... [-h] [-g <level>] [-o <out>] <file>
```
to
```
npdet_to_step (part [-l <level> <name>]...)... [-h] [-g <level>] [-o <out>] <file>
```
When no optional part name is specified, the entire world is converted.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No (this was intended behavior already).