### PR TITLE
correct the wavelength range for optical photons in hpDIRC

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -64,8 +64,8 @@ if __name__ == "__main__":
     {
       "name": "OpticalPhotonEfficiencyStackingAction",
       "parameter": {
-        "LambdaMin": "200*nm",
-        "LambdaMax": "700*nm",
+        "LambdaMin": "180*nm",
+        "LambdaMax": "678*nm",
         "LogicalVolume": "bar_vol",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Currently the efficiency map in stacking action for optical photons in hpDIRC uses the wavelength range 200 - 700 nm. 
This PR changes the range to 180 - 678 nm to match with the range used in standalone DIRC simulation.

### What kind of change does this PR introduce?
- [x ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
