### PR TITLE
feat: support TGeoTessellated in npdet_to_step

### DIFF
--- a/src/geocad/src/TGeoToOCC.h
+++ b/src/geocad/src/TGeoToOCC.h
@@ -24,6 +24,7 @@
 //Root
 #include "TGeoXtru.h"
 #include "TGeoCompositeShape.h"
+#include "TGeoTessellated.h"
 
 #include <fstream>
 
@@ -48,6 +49,7 @@ private:
    TopoDS_Shape OCC_Pgon(Int_t np, Int_t nz, Double_t * p, Double_t phi1, Double_t DPhi, Int_t numpoint);
    TopoDS_Shape OCC_Box(Double_t dx, Double_t dy, Double_t dz, Double_t OX, Double_t OY, Double_t OZ);
    TopoDS_Shape OCC_Trd(Double_t dx1, Double_t dx2, Double_t dy1, Double_t dy2, Double_t dz);
+   TopoDS_Shape OCC_Mesh(TGeoTessellated *tess);
    std::ofstream out;
    TopoDS_Shape fOccShape;
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds support for TGeoTessellated volumes in the export to STEP. Storing meshes in STEP is not really the most efficient way (BHCAL is 71MB as STEP), but it simplifies some workflows.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #21)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, adds support for TGeoTessellated.