### PR TITLE
fix: TGeoFacet::{GetVertexIndex -> operator[]} in ROOT 6.32.00

### DIFF
--- a/src/geocad/src/TGeoToOCC.cxx
+++ b/src/geocad/src/TGeoToOCC.cxx
@@ -250,9 +250,17 @@ TopoDS_Shape TGeoToOCC::OCC_Mesh(TGeoTessellated *tess)
      mesh->SetTriangle(
        i_facet+1,
        Poly_Triangle(
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 0)
+         facet[0]+1,
+         facet[1]+1,
+         facet[2]+1
+#else
          facet.GetVertexIndex(0)+1,
          facet.GetVertexIndex(1)+1,
-         facet.GetVertexIndex(2)+1));
+         facet.GetVertexIndex(2)+1
+#endif
+       )
+     );
    }
    BRepBuilderAPI_MakeShapeOnMesh builder(mesh);
    builder.Build();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
As of https://github.com/root-project/root/commit/aeffc7467d0034c7504229ec9cf52a045316f747, ROOT 6.32.00-rc1, the calling syntax for vertex indices of a TGeoFacet has changed.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.