### PR TITLE
npsim: parse CLI/steering options before we apply our preferences

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
   SIM = DD4hepSimulation()
 
   # Parse remaining options (command line and steering file override above)
-  # XXX This is done before updating the settings to workaround issue reported in
+  # This is done before updating the settings to workaround issue reported in
   # https://github.com/AIDASoft/DD4hep/pull/1376
   SIM.parseOptions()
 

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -20,6 +20,11 @@ if __name__ == "__main__":
 
   SIM = DD4hepSimulation()
 
+  # Parse remaining options (command line and steering file override above)
+  # XXX This is done before updating the settings to workaround issue reported in
+  # https://github.com/AIDASoft/DD4hep/pull/1376
+  SIM.parseOptions()
+
   # Ensure that Cerenkov and optical physics are always loaded
   def setupCerenkov(kernel):
     from DDG4 import PhysicsList
@@ -87,9 +92,6 @@ if __name__ == "__main__":
       }
     }
   ]
-
-  # Parse remaining options (command line and steering file override above)
-  SIM.parseOptions()
 
   try:
     SIM.run()


### PR DESCRIPTION
This is a workaround needed to enforce our settings for SINGLE campaigns. See issue in the comment for more details.