### PR TITLE
feat: DetectorChecksumRunAction to write checksums to podio

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -70,7 +70,13 @@ if __name__ == "__main__":
   RUNNER.action.run = [
     {
       "name": "DetectorChecksumRunAction",
-      "parameter": {}
+      "parameter": {
+        "ignoreDetectors": [
+          "ForwardRomanPot_Station_1",
+          "ForwardRomanPot_Station_2",
+          "RICHEndcapN"
+        ]
+      }
     }
   ]
 

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -67,18 +67,15 @@ if __name__ == "__main__":
   RUNNER.action.mapActions['DIRC'] = 'Geant4OpticalTrackerAction'
 
   # Store detector checksum in run action
-  RUNNER.action.run = [
-    {
-      "name": "DetectorChecksumRunAction",
-      "parameter": {
-        "ignoreDetectors": [
-          "ForwardRomanPot_Station_1",
-          "ForwardRomanPot_Station_2",
-          "RICHEndcapN"
-        ]
+  if len(RUNNER.action.run) == 0:
+    RUNNER.action.run = [
+      {
+        "name": "DetectorChecksumRunAction",
+        "parameter": {
+          "ignoreDetectors": []
+        }
       }
-    }
-  ]
+    ]
 
   # Use the optical photon efficiency stacking action for hpDIRC
   RUNNER.action.stack = [

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -8,6 +8,7 @@ Based on M. Frank and F. Gaede runSim.py
 Modified with standard EIC EPIC requirements.
 """
 from __future__ import absolute_import, unicode_literals
+import argparse
 import logging
 import sys
 
@@ -19,6 +20,13 @@ if __name__ == "__main__":
   logger = logging.getLogger('DDSim')
 
   RUNNER = DD4hepSimulation()
+
+  # Parse our own options
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--disableChecksum", action="store_true", default=False,
+                        help="Disable the detector checksum calculations")
+  args, unknown = parser.parse_known_args()
+  sys.argv = [sys.argv[0]] + unknown
 
   # Parse remaining options (command line and steering file override above)
   # This is done before updating the settings to workaround issue reported in
@@ -67,8 +75,8 @@ if __name__ == "__main__":
   RUNNER.action.mapActions['DIRC'] = 'Geant4OpticalTrackerAction'
 
   # Store detector checksum in run action
-  if len(RUNNER.action.run) == 0:
-    RUNNER.action.run = [
+  if not args.disableChecksum:
+    RUNNER.action.run += [
       {
         "name": "DetectorChecksumRunAction",
         "parameter": {

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -22,11 +22,15 @@ if __name__ == "__main__":
   RUNNER = DD4hepSimulation()
 
   # Parse our own options
-  parser = argparse.ArgumentParser()
+  parser = argparse.ArgumentParser("Running ePIC/EIC Simulations:", add_help=False)
   parser.add_argument("--disableChecksum", action="store_true", default=False,
                         help="Disable the detector checksum calculations")
   args, unknown = parser.parse_known_args()
   sys.argv = [sys.argv[0]] + unknown
+  if "--help" in unknown:
+    parser.print_help()
+    print()
+    print()
 
   # Parse remaining options (command line and steering file override above)
   # This is done before updating the settings to workaround issue reported in

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -66,6 +66,14 @@ if __name__ == "__main__":
   RUNNER.action.mapActions['RICHEndcapN'] = 'Geant4OpticalTrackerAction'
   RUNNER.action.mapActions['DIRC'] = 'Geant4OpticalTrackerAction'
 
+  # Store detector checksum in run action
+  RUNNER.action.run = [
+    {
+      "name": "DetectorChecksumRunAction",
+      "parameter": {}
+    }
+  ]
+
   # Use the optical photon efficiency stacking action for hpDIRC
   RUNNER.action.stack = [
     {

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 dd4hep_add_plugin(NPDetPlugins
   SOURCES
+    src/DetectorChecksumRunAction.cxx
     src/EICInteractionVertexBoost.cxx
     src/EICInteractionVertexSmear.cxx
     src/OpticalPhotonEfficiencyStackingAction.cxx
   INCLUDES $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  USES DD4hep::DDCore DD4hep::DDG4
+  USES DD4hep::DDCore DD4hep::DDCorePlugins DD4hep::DDG4
 )
 
 install(TARGETS NPDetPlugins

--- a/src/plugins/include/npdet/DetectorChecksumRunAction.h
+++ b/src/plugins/include/npdet/DetectorChecksumRunAction.h
@@ -77,16 +77,18 @@ DetectorChecksumRunAction::getHashMap(Detector& detector) const {
   const auto start{std::chrono::steady_clock::now()};
   DetectorChecksum checksum(detector);
   checksum.debug        = 0;
+  checksum.max_level    = -1;
   checksum.precision    = 3;
   checksum.hash_meshes  = true;
   checksum.hash_readout = true;
+  bool checksum_det_element_recursive = true;
   for (const auto& [name, det] : detector.world().children()) {
     if (m_ignoreDetectors.contains(name)) {
       continue;
     }
     checksum.analyzeDetector(det);
     DetectorChecksum::hashes_t hash_vec{checksum.handleHeader().hash};
-    checksum.checksumDetElement(0, det, hash_vec, true);
+    checksum.checksumDetElement(0, det, hash_vec, checksum_det_element_recursive);
     DetectorChecksum::hash_t hash =
         dd4hep::detail::hash64(&hash_vec[0], hash_vec.size() * sizeof(DetectorChecksum::hash_t));
     hashMap[name] = hash;

--- a/src/plugins/include/npdet/DetectorChecksumRunAction.h
+++ b/src/plugins/include/npdet/DetectorChecksumRunAction.h
@@ -16,6 +16,7 @@
 #include <DDG4/Geant4Random.h>
 #include <DDG4/Geant4RunAction.h>
 #include <DDG4/RunParameters.h>
+#include <chrono>
 #include <format>
 
 #if __has_include(<DD4hep/plugins/DetectorChecksum.h>)
@@ -73,6 +74,7 @@ DetectorChecksumRunAction::getHashMap(Detector& detector) const {
 #if __has_include(<DD4hep/plugins/DetectorChecksum.h>)
   // Determine detector checksum
   // FIXME: ctor expects non-const detector
+  const auto start{std::chrono::steady_clock::now()};
   DetectorChecksum checksum(detector);
   checksum.debug        = 0;
   checksum.precision    = 3;
@@ -89,6 +91,9 @@ DetectorChecksumRunAction::getHashMap(Detector& detector) const {
         dd4hep::detail::hash64(&hash_vec[0], hash_vec.size() * sizeof(DetectorChecksum::hash_t));
     hashMap[name] = hash;
   }
+  const auto finish{std::chrono::steady_clock::now()};
+  const std::chrono::duration<double> elapsed_seconds{finish - start};
+  printout(INFO,"DetectorChecksumRunAction::getHashMap", "duration: %f seconds", elapsed_seconds.count());
 #endif
   return hashMap;
 }

--- a/src/plugins/include/npdet/DetectorChecksumRunAction.h
+++ b/src/plugins/include/npdet/DetectorChecksumRunAction.h
@@ -43,13 +43,16 @@ namespace sim {
     public:
       /// Standard constructor with initializing arguments
       DetectorChecksumRunAction(Geant4Context* c, const std::string& n)
-      : Geant4RunAction(c, n) {};
+      : Geant4RunAction(c, n) {
+        declareProperty("ignoreDetectors", m_ignoreDetectors);
+      };
       /// Default destructor
       virtual ~DetectorChecksumRunAction() {};
 
       void begin(const G4Run* run);
     private:
       hashMap_t getHashMap(Detector& detector);
+      std::set<std::string> m_ignoreDetectors;
     };
 
 void DetectorChecksumRunAction::begin(const G4Run* /* run */) {
@@ -74,6 +77,9 @@ DetectorChecksumRunAction::getHashMap(Detector& detector) {
     checksum.hash_meshes  = true;
     checksum.hash_readout = true;
     for (const auto& [name, det] : detector.world().children()) {
+      if (m_ignoreDetectors.contains(name)) {
+        continue;
+      }
       checksum.analyzeDetector(det);
       DetectorChecksum::hashes_t hash_vec{checksum.handleHeader().hash};
       checksum.checksumDetElement(0, det, hash_vec, true);

--- a/src/plugins/include/npdet/DetectorChecksumRunAction.h
+++ b/src/plugins/include/npdet/DetectorChecksumRunAction.h
@@ -1,0 +1,91 @@
+//==========================================================================
+//  AIDA Detector description implementation 
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef DETECTORCHECKSUMRUNACTION_H
+#define DETECTORCHECKSUMRUNACTION_H
+
+#include "DDG4/Geant4Random.h"
+#include "DDG4/Geant4RunAction.h"
+#include <DDG4/RunParameters.h>
+
+#if __has_include(<DD4hep/plugins/DetectorChecksum.h>)
+#include <DD4hep/plugins/DetectorChecksum.h>
+#endif
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+        
+/// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+namespace sim {
+
+    using dd4hep::detail::DetectorChecksum;
+    using hashMap_t = std::map<std::string, DetectorChecksum::hash_t>;
+
+    template <class T = hashMap_t> void RunParameters::ingestParameters(T const& hashMap) {
+      for (auto& [name, hash] : hashMap) {
+        // hashes are 64 bit, so we have to cast to string
+        // FIXME: should be hex string since that's printed
+        // FIXME: suffix or prefix with "hash"
+        m_strValues[name.c_str()] = {std::to_string(hash)};
+      }
+    }
+
+    class DetectorChecksumRunAction: public Geant4RunAction {
+    public:
+      /// Standard constructor with initializing arguments
+      DetectorChecksumRunAction(Geant4Context* c, const std::string& n)
+      : Geant4RunAction(c, n) {};
+      /// Default destructor
+      virtual ~DetectorChecksumRunAction() {};
+
+      void begin(const G4Run* run);
+    private:
+      hashMap_t getHashMap(Detector& detector);
+    };
+
+void DetectorChecksumRunAction::begin(const G4Run* /* run */) {
+  try {
+    auto *parameters = new RunParameters();
+    parameters->ingestParameters(getHashMap(context()->detectorDescription()));
+    context()->run().addExtension<RunParameters>(parameters);
+  } catch(std::exception &e) {
+    printout(ERROR,"DetectorChecksumRunAction::begin","Failed to register run parameters: %s", e.what());
+  }
+}
+
+std::map<std::string,DetectorChecksum::hash_t>
+DetectorChecksumRunAction::getHashMap(Detector& detector) {
+  std::map<std::string, DetectorChecksum::hash_t> hashMap;
+#if __has_include(<DD4hep/plugins/DetectorChecksum.h>)
+    // Determine detector checksum
+    // FIXME: ctor expects non-const detector
+    DetectorChecksum checksum(detector);
+    checksum.debug        = 0;
+    checksum.precision    = 3;
+    checksum.hash_meshes  = true;
+    checksum.hash_readout = true;
+    for (const auto& [name, det] : detector.world().children()) {
+      checksum.analyzeDetector(det);
+      DetectorChecksum::hashes_t hash_vec{checksum.handleHeader().hash};
+      checksum.checksumDetElement(0, det, hash_vec, true);
+      DetectorChecksum::hash_t hash =
+          dd4hep::detail::hash64(&hash_vec[0], hash_vec.size() * sizeof(DetectorChecksum::hash_t));
+      hashMap[name] = hash;
+    }
+#endif
+  return hashMap;
+}
+
+} // End namespace sim
+} // End namespace dd4hep
+
+#endif // DETECTORCHECKSUMRUNACTION_H

--- a/src/plugins/include/npdet/DetectorChecksumRunAction.h
+++ b/src/plugins/include/npdet/DetectorChecksumRunAction.h
@@ -56,18 +56,12 @@ namespace sim {
 
 void DetectorChecksumRunAction::begin(const G4Run* /* run */) {
   try {
-    bool newParameters{false};
-    RunParameters* parameters = nullptr;
-    try {
-      parameters = context()->run().extension<RunParameters>();
-    } catch (std::exception& e) {
+    auto* parameters = context()->run().extension<RunParameters>(false);
+    if (!parameters) {
       parameters = new RunParameters();
-      newParameters = true;
-    }
-    parameters->ingestParameters(getHashMap(context()->detectorDescription()));
-    if (newParameters) {
       context()->run().addExtension<RunParameters>(parameters);
     }
+    parameters->ingestParameters(getHashMap(context()->detectorDescription()));
   } catch(std::exception &e) {
     printout(ERROR,"DetectorChecksumRunAction::begin","Failed to register run parameters: %s", e.what());
   }

--- a/src/plugins/include/npdet/DetectorChecksumRunAction.h
+++ b/src/plugins/include/npdet/DetectorChecksumRunAction.h
@@ -73,6 +73,7 @@ DetectorChecksumRunAction::getHashMap(Detector& detector) const {
   std::map<std::string, DetectorChecksum::hash_t> hashMap;
 #if __has_include(<DD4hep/plugins/DetectorChecksum.h>)
   // Determine detector checksum
+  printout(INFO,"DetectorChecksumRunAction::getHashMap", "determining checksum... (disable with --disableChecksum)");
   // FIXME: ctor expects non-const detector
   const auto start{std::chrono::steady_clock::now()};
   DetectorChecksum checksum(detector);
@@ -87,7 +88,7 @@ DetectorChecksumRunAction::getHashMap(Detector& detector) const {
       continue;
     }
     checksum.analyzeDetector(det);
-    DetectorChecksum::hashes_t hash_vec{checksum.handleHeader().hash};
+    DetectorChecksum::hashes_t hash_vec{};
     checksum.checksumDetElement(0, det, hash_vec, checksum_det_element_recursive);
     DetectorChecksum::hash_t hash =
         dd4hep::detail::hash64(&hash_vec[0], hash_vec.size() * sizeof(DetectorChecksum::hash_t));

--- a/src/plugins/src/DetectorChecksumRunAction.cxx
+++ b/src/plugins/src/DetectorChecksumRunAction.cxx
@@ -1,0 +1,5 @@
+#include "DDG4/Factories.h"
+
+#include "npdet/DetectorChecksumRunAction.h"
+
+DECLARE_GEANT4ACTION(DetectorChecksumRunAction)

--- a/src/tools/src/dd_web_display.cxx
+++ b/src/tools/src/dd_web_display.cxx
@@ -221,7 +221,7 @@ void run_http_server(const settings& s) {
                                                std::string("?top=geometry&thrds=1;rw;noglobal"))
                                                   .c_str()); 
 
-  spdlog::info("Creating display server at http://{}:{}",s.http_host,s.http_port);
+  //spdlog::info("Creating display server at http://{}:{}",s.http_host,s.http_port);
   if( !(serv->IsAnyEngine()) ) {
     spdlog::error("Failed to start http server.");
     std::exit(-1);

--- a/src/tools/src/dd_web_display.cxx
+++ b/src/tools/src/dd_web_display.cxx
@@ -221,7 +221,7 @@ void run_http_server(const settings& s) {
                                                std::string("?top=geometry&thrds=1;rw;noglobal"))
                                                   .c_str()); 
 
-  //spdlog::info("Creating display server at http://{}:{}",s.http_host,s.http_port);
+  spdlog::info("Creating display server at http://{}:{}",s.http_host,s.http_port);
   if( !(serv->IsAnyEngine()) ) {
     spdlog::error("Failed to start http server.");
     std::exit(-1);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR determines the detector checksums for all detectors, and writes them to the run metadata of the output file.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, it will by default calculate the checksums.

Calculating the checksum currently takes about 20 to 30 seconds in CI (https://github.com/eic/epic/actions/runs/14718107525/job/41444662641#step:5:252), though locally this can take up to 50 seconds. The checksum can be disabled with the npsim argument `--disableChecksum`.