### PR TITLE
fix: support TGeoCompositeShape for world volume

### DIFF
--- a/src/geocad/src/TOCCToStep.cxx
+++ b/src/geocad/src/TOCCToStep.cxx
@@ -79,7 +79,11 @@ TDF_Label TOCCToStep::OCCShapeCreation(TGeoManager *m, double tgeo_length_unit_i
    Int_t level = 0;
    TIter next(m->GetListOfVolumes());
    fLabel = XCAFDoc_DocumentTool::ShapeTool(fDoc->Main())->NewShape();
-   fShape = fRootShape.OCC_SimpleShape(m->GetTopVolume()->GetShape());
+   if (m->GetTopVolume()->GetShape()->IsA()==TGeoCompositeShape::Class()) {
+     fShape = fRootShape.OCC_CompositeShape((TGeoCompositeShape*)m->GetTopVolume()->GetShape(), TGeoIdentity());
+   } else {
+     fShape = fRootShape.OCC_SimpleShape(m->GetTopVolume()->GetShape());
+   }
    XCAFDoc_DocumentTool::ShapeTool(fDoc->Main())->SetShape(fLabel, fShape);
    TDataStd_Name::Set(fLabel, m->GetTopVolume()->GetName());
    XCAFDoc_DocumentTool::ShapeTool(fDoc->Main())->UpdateAssemblies();//fDoc->Main());


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes https://github.com/eic/epic/pull/896#issuecomment-2998416698, i.e. adds support for TGeoCompositeShape as world volumes (think: unions of other shapes).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/epic/pull/896#issuecomment-2998416698)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.