### PR TITLE
feat: add performance profiler as stepping action

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -93,6 +93,10 @@ if __name__ == "__main__":
     }
   ]
 
+  RUNNER.action.step = {
+    "name": "PerformanceProfileSteppingAction"
+  }
+
   try:
     sys.exit(RUNNER.run())
   except NameError as e:

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -7,7 +7,7 @@ dd4hep_add_plugin(NPDetPlugins
     src/OpticalPhotonEfficiencyStackingAction.cxx
     src/PerformanceProfileSteppingAction.cxx
   INCLUDES $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  USES DD4hep::DDCore DD4hep::DDG4
+  USES DD4hep::DDCore DD4hep::DDG4 ROOT::Core
 )
 
 install(TARGETS NPDetPlugins

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -5,6 +5,7 @@ dd4hep_add_plugin(NPDetPlugins
     src/EICInteractionVertexBoost.cxx
     src/EICInteractionVertexSmear.cxx
     src/OpticalPhotonEfficiencyStackingAction.cxx
+    src/PerformanceProfileSteppingAction.cxx
   INCLUDES $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   USES DD4hep::DDCore DD4hep::DDG4
 )

--- a/src/plugins/include/npdet/PerformanceProfileSteppingAction.h
+++ b/src/plugins/include/npdet/PerformanceProfileSteppingAction.h
@@ -1,0 +1,95 @@
+//==========================================================================
+//  AIDA Detector description implementation
+//--------------------------------------------------------------------------
+// Copyright (C) Organisation europeenne pour la Recherche nucleaire (CERN)
+// All rights reserved.
+//
+// For the licensing terms see $DD4hepINSTALL/LICENSE.
+// For the list of contributors see $DD4hepINSTALL/doc/CREDITS.
+//
+// Author     : M.Frank
+//
+//==========================================================================
+#ifndef PERFORMANCEPROFILESTEPPINGACTION_H
+#define PERFORMANCEPROFILESTEPPINGACTION_H
+
+#include "DDG4/Geant4SteppingAction.h"
+#include "G4Step.hh"
+
+#include <chrono>
+using namespace std::chrono_literals;
+
+/// Namespace for the AIDA detector description toolkit
+namespace dd4hep {
+
+  /// Namespace for the Geant4 based simulation part of the AIDA detector description toolkit
+  namespace sim {
+
+    class PerformanceProfileSteppingAction : public Geant4SteppingAction {
+     public:
+      /// Standard constructor with initializing arguments
+      PerformanceProfileSteppingAction(Geant4Context* c, const std::string& n) : Geant4SteppingAction(c, n) {};
+      /// Default destructor
+      virtual ~PerformanceProfileSteppingAction() {
+        std::chrono::milliseconds total_duration = std::chrono::milliseconds::zero();
+        for (auto& [track_id, duration] : m_duration) {
+          if (std::chrono::abs(duration) > std::chrono::nanoseconds(10ms)) {
+            auto p0 = m_prestep_position[track_id] / CLHEP::mm;
+            auto p1 = m_poststep_position[track_id] / CLHEP::mm;
+            auto E1 = m_pdg[track_id] == -22 ? m_poststep_energy[track_id] / CLHEP::eV
+                                             : m_poststep_energy[track_id] / CLHEP::MeV;
+            printout(INFO, name(), "track %d (%d): %ld ms (%f %f %f mm -> %f %f %f mm, %f (M?)eV)", track_id,
+                     m_pdg[track_id], std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(), p0.x(),
+                     p0.y(), p0.z(), p1.x(), p1.y(), p1.z(), E1);
+          }
+          total_duration += std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+        }
+        printout(INFO, name(), "total duration: %ld ms", total_duration);
+      };
+      /// User stepping callback
+      void operator()(const G4Step* step, G4SteppingManager*) override {
+        auto* track                      = step->GetTrack();
+        auto* particle                   = track->GetParticleDefinition();
+        auto  pdg                        = particle->GetPDGEncoding();
+        auto  track_id                   = track->GetTrackID();
+        auto* prestep [[maybe_unused]]   = step->GetPreStepPoint();
+        auto  prestep_position           = prestep->GetPosition();
+        auto* poststep [[maybe_unused]]  = step->GetPostStepPoint();
+        auto  poststep_position          = poststep->GetPosition();
+        auto  poststep_energy            = poststep->GetTotalEnergy();
+        auto  firststep [[maybe_unused]] = step->IsFirstStepInVolume();
+        auto  laststep [[maybe_unused]]  = step->IsLastStepInVolume();
+        if (track_id == m_previous_track_id) {
+          m_duration[track_id] += (std::chrono::steady_clock::now() - m_previous_timepoint);
+          m_poststep_position[track_id] = poststep_position;
+          m_poststep_energy[track_id]   = poststep_energy;
+        } else {
+          if (track_id == 0) {
+            m_duration.clear();
+            m_pdg.clear();
+            m_prestep_position.clear();
+            m_poststep_position.clear();
+            m_poststep_energy.clear();
+            printout(INFO, name(), "new event");
+          }
+          m_previous_track_id          = track_id;
+          m_pdg[track_id]              = pdg;
+          m_duration[track_id]         = std::chrono::nanoseconds::zero();
+          m_prestep_position[track_id] = prestep_position;
+        }
+        m_previous_timepoint = std::chrono::steady_clock::now();
+      };
+
+     private:
+      std::map<G4int, std::chrono::nanoseconds>          m_duration;
+      std::map<G4int, G4int>                             m_pdg;
+      std::map<G4int, G4ThreeVector>                     m_prestep_position;
+      std::map<G4int, G4ThreeVector>                     m_poststep_position;
+      std::map<G4int, G4double>                          m_poststep_energy;
+      G4int                                              m_previous_track_id{0};
+      std::chrono::time_point<std::chrono::steady_clock> m_previous_timepoint;
+    };
+  } // End namespace sim
+} // End namespace dd4hep
+
+#endif // PERFORMANCEPROFILESTEPPINGACTION_H

--- a/src/plugins/src/PerformanceProfileSteppingAction.cxx
+++ b/src/plugins/src/PerformanceProfileSteppingAction.cxx
@@ -1,0 +1,5 @@
+#include "DDG4/Factories.h"
+
+#include "npdet/PerformanceProfileSteppingAction.h"
+
+DECLARE_GEANT4ACTION(PerformanceProfileSteppingAction)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a performance profiler plugin as a stepping action. For each step it keeps track of the duration that it is being simulated (this only works for default stacking actions), and at the end of run lists all tracks that took longer than 10 ms to simulate, along with their PDG and start/end position.

Example output:
```
PerformanceProfileSteppingAction INFO  track 1 (2212): 12 ms (0.029269 -0.004519 1.757631 mm -> -102.125110 -73.161965 6923.859749 mm, 938.270000 (M?)eV)
PerformanceProfileSteppingAction INFO  track 9 (-321): 10 ms (0.029269 -0.004519 1.757631 mm -> -277.006274 -1473.096044 3519.430984 mm, 493.680000 (M?)eV)
PerformanceProfileSteppingAction INFO  track 10 (211): 13 ms (0.029269 -0.004519 1.757631 mm -> -396.945489 -787.958616 1582.872183 mm, 139.570000 (M?)eV)
PerformanceProfileSteppingAction INFO  track 6181 (-22): 15 ms (106.995649 776.761659 -401.489860 mm -> 107.365071 778.207138 -1545.354784 mm, 3.783558 (M?)eV)
PerformanceProfileSteppingAction INFO  track 6267 (-22): 10 ms (107.289909 778.630931 -402.464097 mm -> 107.502939 763.628645 226.130404 mm, 2.407724 (M?)eV)
PerformanceProfileSteppingAction INFO  track 25248 (-22): 31 ms (123.662639 764.565346 -439.257661 mm -> 138.962176 775.684364 -326.500907 mm, 3.491873 (M?)eV)
PerformanceProfileSteppingAction INFO  track 27569 (11): 14 ms (166.477612 -1121.195617 2351.318946 mm -> 140.948726 -1200.141784 2569.490636 mm, 0.510999 (M?)eV)
PerformanceProfileSteppingAction INFO  track 27813 (2112): 15 ms (-456.534854 -711.108410 1607.115610 mm -> -70.120630 1923.261126 1245.808178 mm, 939.565361 (M?)eV)
PerformanceProfileSteppingAction INFO  track 27858 (2112): 22 ms (-1288.722733 -345.548613 2264.401897 mm -> -2053.894041 83.307443 2732.565622 mm, 939.565360 (M?)eV)
PerformanceProfileSteppingAction INFO  track 28452 (2112): 15 ms (117.221294 -1963.661356 2019.896461 mm -> 34.670203 -2049.162650 1986.983329 mm, 939.565360 (M?)eV)
PerformanceProfileSteppingAction INFO  track 28465 (2112): 10 ms (224.358432 -1940.989177 2055.132725 mm -> 1135.633326 -1753.395162 2048.960419 mm, 939.565361 (M?)eV)
PerformanceProfileSteppingAction INFO  track 29245 (2112): 11 ms (-692.575491 -699.084520 1687.174783 mm -> 1600.277864 -385.261933 1253.103476 mm, 939.565476 (M?)eV)
PerformanceProfileSteppingAction INFO  track 29563 (-22): 43 ms (-108.498510 -763.717067 1416.221122 mm -> -134.371499 -772.001318 1302.836329 mm, 3.648589 (M?)eV)
PerformanceProfileSteppingAction INFO  track 29955 (2112): 26 ms (-734.443022 1845.196633 3137.381185 mm -> -1352.866966 1398.789799 3453.263058 mm, 939.565360 (M?)eV)
PerformanceProfileSteppingAction INFO  track 31505 (14): 10 ms (-873.428301 -1434.637187 3454.402212 mm -> 2466.324741 -3500.000000 599.340318 mm, 29.791916 (M?)eV)
```

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.
