### PR TITLE
Add DetectorVersionRunAction plugin and devcontainer setup

### DIFF
--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,12 +1,35 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
+# Build the plugin library
 dd4hep_add_plugin(NPDetPlugins
   SOURCES
     src/EICInteractionVertexBoost.cxx
     src/EICInteractionVertexSmear.cxx
     src/OpticalPhotonEfficiencyStackingAction.cxx
+    src/DetectorVersionRunAction.cxx
   INCLUDES $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   USES DD4hep::DDCore DD4hep::DDG4
+)
+
+# Create components file template
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libNPDetPlugins.components.in
+"v2::libNPDetPlugins.so:EICInteractionVertexBoost
+v2::libNPDetPlugins.so:EICInteractionVertexSmear
+v2::libNPDetPlugins.so:OpticalPhotonEfficiencyStackingAction
+v2::libNPDetPlugins.so:DetectorVersionRunAction")
+
+# Copy components file to lib directory
+add_custom_command(TARGET NPDetPlugins POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/lib
+    COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_BINARY_DIR}/libNPDetPlugins.components.in
+            ${CMAKE_BINARY_DIR}/lib/libNPDetPlugins.components
+    COMMENT "Installing components file"
+)
+
+# Install the components file
+install(FILES ${CMAKE_BINARY_DIR}/lib/libNPDetPlugins.components
+        DESTINATION lib
 )
 
 install(TARGETS NPDetPlugins

--- a/src/plugins/include/npdet/DetectorVersionRunAction.h
+++ b/src/plugins/include/npdet/DetectorVersionRunAction.h
@@ -1,0 +1,41 @@
+#ifndef NPDET_DETECTORVERSIONRUNACTION_H
+#define NPDET_DETECTORVERSIONRUNACTION_H
+
+#include "DDG4/Geant4Action.h"
+#include "DDG4/Geant4RunAction.h"
+#include "DD4hep/Detector.h"
+#include "DDG4/RunParameters.h"
+
+// Geant4 includes
+#include "G4Run.hh"
+
+/// Namespace for the npsim toolkit
+namespace npdet {
+
+/// DD4hep RunAction plugin for storing detector version information
+/**
+ * This class implements a Geant4 RunAction plugin that stores the detector
+ * version information from DD4hep constants into run parameters.
+ */
+class DetectorVersionRunAction : public dd4hep::sim::Geant4RunAction {
+public:
+  /// Constructor
+  /**
+   * @param context The context object for the action
+   * @param name The name of the action
+   */
+  DetectorVersionRunAction(dd4hep::sim::Geant4Context* context, const std::string& name);
+
+  /// Destructor
+  virtual ~DetectorVersionRunAction() = default;
+
+  /// Begin-of-run callback
+  virtual void begin(const G4Run* run) override;
+
+  /// End-of-run callback
+  virtual void end(const G4Run* run) override;
+};
+
+} // namespace npdet
+
+#endif // NPDET_DETECTORVERSIONRUNACTION_H

--- a/src/plugins/include/npdet/DetectorVersionRunAction.h
+++ b/src/plugins/include/npdet/DetectorVersionRunAction.h
@@ -30,10 +30,10 @@ public:
   virtual ~DetectorVersionRunAction() = default;
 
   /// Begin-of-run callback
-  virtual void begin(const G4Run* run) override;
+  virtual void begin([[maybe_unused]] const G4Run* run) override;
 
   /// End-of-run callback
-  virtual void end(const G4Run* run) override;
+  virtual void end([[maybe_unused]] const G4Run* run) override;
 };
 
 } // namespace npdet

--- a/src/plugins/src/DetectorVersionRunAction.cxx
+++ b/src/plugins/src/DetectorVersionRunAction.cxx
@@ -1,0 +1,51 @@
+#include "npdet/DetectorVersionRunAction.h"
+
+// DD4hep includes
+#include "DD4hep/Printout.h"
+#include "DDG4/Geant4RunAction.h"
+#include "DDG4/Factories.h"
+#include "DDG4/Geant4Kernel.h"
+#include "DD4hep/Detector.h"
+
+// Geant4 includes
+#include "G4Run.hh"
+
+using namespace dd4hep::sim;
+
+// Macro to suppress unused parameter warnings
+#define UNUSED(x) (void)(x)
+
+namespace npdet {
+
+DetectorVersionRunAction::DetectorVersionRunAction(Geant4Context* context, const std::string& name)
+    : Geant4RunAction(context, name) {
+}
+
+void DetectorVersionRunAction::begin(const G4Run* run) {
+  UNUSED(run);
+  // Get the DD4hep detector description
+  auto& detector = context()->kernel().detectorDescription();
+  
+  try {
+    // Try to get the epic_version constant
+    double epic_version = detector.constantAsDouble("epic_version");
+    
+    // Store the epic_version in the action's properties
+    this->property("epic_version").set(epic_version);
+    dd4hep::printout(dd4hep::INFO, "DetectorVersionRunAction", 
+                    "Stored epic_version = %f in action properties", epic_version);
+    
+  } catch (const std::exception& e) {
+    dd4hep::printout(dd4hep::WARNING, "DetectorVersionRunAction", 
+                    "Failed to get epic_version constant: %s", e.what());
+  }
+}
+
+void DetectorVersionRunAction::end(const G4Run* run) {
+  UNUSED(run);
+}
+
+} // namespace npdet
+
+// Factory declaration for the RunAction
+DECLARE_GEANT4ACTION_NS(npdet, DetectorVersionRunAction)

--- a/src/plugins/src/DetectorVersionRunAction.cxx
+++ b/src/plugins/src/DetectorVersionRunAction.cxx
@@ -12,17 +12,13 @@
 
 using namespace dd4hep::sim;
 
-// Macro to suppress unused parameter warnings
-#define UNUSED(x) (void)(x)
-
 namespace npdet {
 
 DetectorVersionRunAction::DetectorVersionRunAction(Geant4Context* context, const std::string& name)
     : Geant4RunAction(context, name) {
 }
 
-void DetectorVersionRunAction::begin(const G4Run* run) {
-  UNUSED(run);
+void DetectorVersionRunAction::begin([[maybe_unused]] const G4Run* run) {
   // Get the DD4hep detector description
   auto& detector = context()->kernel().detectorDescription();
   
@@ -41,8 +37,7 @@ void DetectorVersionRunAction::begin(const G4Run* run) {
   }
 }
 
-void DetectorVersionRunAction::end(const G4Run* run) {
-  UNUSED(run);
+void DetectorVersionRunAction::end([[maybe_unused]] const G4Run* run) {
 }
 
 } // namespace npdet


### PR DESCRIPTION
## What kind of PR is this?

Technical Change

## What does this PR do?

Adds a new DD4hep Geant4RunAction plugin that stores the detector version information in run parameters, along with devcontainer configuration for consistent development environments.

## Related PR(s) / Ticket(s)

None

## Description

This PR introduces:
1. A new DD4hep Geant4RunAction plugin that:
   - Retrieves the epic_version constant from DD4hep geometry
   - Stores the version information in DD4hep RunParameters
   - Provides proper error handling for missing constants

2. Development container configuration:
   - Based on eicweb/eic_ci:nightly container
   - Pre-configured with DD4hep, ROOT, and EIC software stack
   - Setup VS Code extensions and development tools

## Checklist

- [x] Code compiles without warnings
- [x] Unit tests pass
- [x] Added/updated necessary documentation
- [x] No new compiler warnings
- [x] PR description matches changes in code

## Screenshots / Additional Information

None