### PR TITLE
fix: add null check for optical photon volume

### DIFF
--- a/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
+++ b/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
@@ -55,6 +55,7 @@ namespace dd4hep {
         // Only apply to optical photons
         if (aTrack->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
           auto* pv = aTrack->GetVolume();
+          if (pv == nullptr) return TrackClassification();
           auto* lv = pv->GetLogicalVolume();
           printout(VERBOSE, name(), "photon in pv %s lv %s",
             pv->GetName().c_str(), lv->GetName().c_str());


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes a segfault crash where a nullptr is returned as the optical photon's physical volume. This happens in certain scenarios when an optical photon is not inside a physical volume, for example when it is only in the world volume. A GPS that shoots optical photons from outside any placed volumes to an e.g. DIRC only geometry will be in this case.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://chat.epic-eic.org/main/pl/34f6bnjhy7n5tfeirfhe8t11jw)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Blocker for @wjllope's simulations for hpDIRC. FYI @veprbl.

AI used for identifying based on geant4 source tree under which conditions a valid track can have a null volume pointer.