### PR TITLE
tools: add npdet_to_dot geometry tree visualizer

### DIFF
--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -40,8 +40,8 @@ jobs:
           path: .
       - name: Uncompress install artifact
         run: tar -xaf install.tar.zst
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-      - uses: eic/run-cvmfs-osg-eic-shell@main
+      - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4  # v5
+      - uses: eic/run-cvmfs-osg-eic-shell@3b80777ba49c2e6f802256753bbc11563ecf4636  # main
         with:
           organization: "${{ inputs.organization }}"
           platform-release: "${{ inputs.platform-release }}"

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -1,0 +1,64 @@
+name: Convert to DOT
+
+on:
+  workflow_call:
+    inputs:
+      detector_configs:
+        required: true
+        type: string
+      install_artifact_name:
+        required: true
+        type: string
+      organization:
+        required: false
+        type: string
+        default: eicweb
+      platform-release:
+        required: false
+        type: string
+        default: eic_xl:nightly
+      epic_setup_script:
+        required: false
+        type: string
+        default: /opt/detector/epic-main/bin/thisepic.sh
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  convert-to-dot:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        detector_config: ${{fromJson(inputs.detector_configs)}}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.install_artifact_name }}
+          path: .
+      - name: Uncompress install artifact
+        run: tar -xaf install.tar.zst
+      - uses: cvmfs-contrib/github-action-cvmfs@v5
+      - uses: eic/run-cvmfs-osg-eic-shell@main
+        with:
+          organization: "${{ inputs.organization }}"
+          platform-release: "${{ inputs.platform-release }}"
+          setup: ${{ inputs.epic_setup_script }}
+          run: |
+            export PATH=$PWD/install/bin${PATH:+:$PATH}
+            export LD_LIBRARY_PATH=$PWD/install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+            npdet_to_dot list -d 3 -o ${{matrix.detector_config}} $DETECTOR_PATH/${{matrix.detector_config}}.xml
+            test -s ${{matrix.detector_config}}.dot
+      - name: Install Graphviz
+        run: sudo apt-get install -y graphviz
+      - name: Convert DOT to SVG
+        run: dot -Tsvg ${{matrix.detector_config}}.dot -o ${{matrix.detector_config}}.svg
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{matrix.detector_config}}.dot
+          path: |
+            ${{matrix.detector_config}}.dot
+            ${{matrix.detector_config}}.svg
+          if-no-files-found: error

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -230,6 +230,16 @@ jobs:
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
 
+  convert-to-dot:
+    needs:
+      - build
+    uses: ./.github/workflows/convert-to-dot.yml
+    with:
+      detector_configs: '["epic_craterlake_no_bhcal","epic_imaging_only","epic_drich_only","epic_dirc_only","epic_craterlake_tracking_only","epic_ip6"]'
+      install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
+      organization: "${{ inputs.organization || 'eicweb' }}"
+      platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
+
   merge-npsim-capybara:
     runs-on: ubuntu-latest
     needs:

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -122,6 +122,24 @@ else()
 endif()
 
 # ------------------------------------
+# npdet_to_dot
+# ------------------------------------
+set(exe_name npdet_to_dot)
+add_executable(${exe_name} src/${exe_name}.cxx)
+target_include_directories(${exe_name}
+  PRIVATE include)
+target_compile_features(${exe_name}
+  PUBLIC cxx_std_17
+  PUBLIC cxx_auto_type
+  PUBLIC cxx_trailing_return_types
+  PRIVATE cxx_variadic_templates)
+target_link_libraries(${exe_name}
+  PUBLIC DD4hep::DDCore ROOT::Core ROOT::Geom)
+install(TARGETS ${exe_name}
+  EXPORT NPDetTargets
+  RUNTIME DESTINATION bin)
+
+# ------------------------------------
 # npdet_info
 # ------------------------------------
 set(exe_name npdet_info)

--- a/src/tools/src/npdet_to_dot.cxx
+++ b/src/tools/src/npdet_to_dot.cxx
@@ -14,6 +14,7 @@
 // number of child instances per parent instance (the logical multiplicity).
 
 #include <cassert>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -58,7 +59,7 @@ struct dot_settings {
 // Unique node ID derived from pointer address
 static std::string dot_id(const TGeoVolume* vol) {
   std::ostringstream ss;
-  ss << "v" << reinterpret_cast<uintptr_t>(vol);
+  ss << "v" << reinterpret_cast<std::uintptr_t>(vol);
   return ss.str();
 }
 
@@ -278,6 +279,10 @@ int main(int argc, char* argv[]) {
   std::string title = fs::path(s.infile).stem().string();
 
   if (s.selected == dot_mode::part) {
+    if (s.part_name_levels.empty()) {
+      std::cerr << "Error: 'part' mode requires at least one volume name\n";
+      return 1;
+    }
     write_dot(out, geo, s.part_name_levels, -1, title);
   } else {
     // list mode: use default_level

--- a/src/tools/src/npdet_to_dot.cxx
+++ b/src/tools/src/npdet_to_dot.cxx
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2025 EIC Collaboration
+//
+// npdet_to_dot: Generate Graphviz DOT files from a DD4hep/TGeo geometry.
+//
+// Each unique logical volume (TGeoVolume*) becomes one DOT node, colored by
+// how many times it is instantiated in the traversed subtree:
+//   gray        - placed exactly once
+//   lemonchiffon - placed 2-9 times
+//   lightgreen  - placed 10-99 times
+//   skyblue     - placed 100+ times
+//
+// Edges connect parent to child logical volume and are labelled with the
+// number of child instances per parent instance (the logical multiplicity).
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+#include <TGeoManager.h>
+#include <TGeoNode.h>
+#include <TGeoVolume.h>
+
+#include <DD4hep/Detector.h>
+#include <DD4hep/Printout.h>
+
+#include "clipp.h"
+using namespace clipp;
+
+// ---------------------------------------------------------------------------
+// Minimal settings for this tool
+// ---------------------------------------------------------------------------
+
+enum class dot_mode { none, help, list, part };
+
+struct dot_settings {
+  bool     success        = false;
+  dot_mode selected       = dot_mode::list;
+  std::string infile      = "";
+  std::string outfile     = "geometry";
+  int         default_level = 2;
+  bool        level_set   = false;
+  int         part_level  = 2;
+  std::map<std::string, int> part_name_levels;
+};
+
+// ---------------------------------------------------------------------------
+// DOT helpers
+// ---------------------------------------------------------------------------
+
+// Unique node ID derived from pointer address
+static std::string dot_id(const TGeoVolume* vol) {
+  std::ostringstream ss;
+  ss << "v" << reinterpret_cast<uintptr_t>(vol);
+  return ss.str();
+}
+
+// Escape a volume name for use inside a DOT quoted string label
+static std::string dot_escape(const std::string& s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    if (c == '"' || c == '\\') out += '\\';
+    out += c;
+  }
+  return out;
+}
+
+// Node fill color based on total placement count in the traversed subtree
+static std::string placement_color(int count) {
+  if (count < 2)   return "#d3d3d3";  // lightgray
+  if (count < 10)  return "#fffacd";  // lemonchiffon
+  if (count < 100) return "#90ee90";  // lightgreen
+  return "#87ceeb";                   // skyblue
+}
+
+// ---------------------------------------------------------------------------
+// Core DOT writer
+// ---------------------------------------------------------------------------
+
+void write_dot(std::ostream& out, TGeoManager* geo,
+               const std::map<std::string, int>& part_name_levels,
+               int default_max_level, const std::string& title) {
+
+  TGeoVolume* world      = geo->GetTopVolume();
+  TGeoNode*   world_node = geo->GetTopNode();
+
+  bool part_mode = !part_name_levels.empty();
+
+  // Traversal state
+  std::map<TGeoVolume*, int>                              vol_count;   // total placements in traversal
+  std::map<std::pair<TGeoVolume*, TGeoVolume*>, int>      edge_total;  // total (parent,child) visits
+  std::set<TGeoVolume*>                                   volumes;
+
+  volumes.insert(world);
+  vol_count[world] = 1;
+
+  bool        found_in_level_1 = !part_mode;
+  std::string matched_part;
+
+  TGeoIterator it(world);
+  TGeoNode*    currentNode = nullptr;
+  it.SetType(0);
+
+  while ((currentNode = it())) {
+    it.SetType(0);
+    int level = it.GetLevel();
+
+    // Part-mode gate at level 1
+    if (part_mode && level == 1) {
+      found_in_level_1 = false;
+      matched_part.clear();
+      for (auto& [name, _] : part_name_levels) {
+        if (std::string(currentNode->GetVolume()->GetName()) == name) {
+          found_in_level_1 = true;
+          matched_part     = name;
+          break;
+        }
+      }
+    }
+    if (!found_in_level_1) { it.Skip(); continue; }
+
+    int cur_max = part_mode ? part_name_levels.at(matched_part) : default_max_level;
+    if (cur_max >= 0 && level > cur_max) { it.Skip(); continue; }
+
+    TGeoVolume* child_vol  = currentNode->GetVolume();
+    TGeoNode*   parent_node = (level == 1) ? world_node : it.GetNode(level - 1);
+    TGeoVolume* parent_vol  = parent_node->GetVolume();
+
+    volumes.insert(child_vol);
+    volumes.insert(parent_vol);
+    vol_count[child_vol]++;
+    edge_total[{parent_vol, child_vol}]++;
+
+    if (cur_max >= 0 && level == cur_max) it.Skip();
+  }
+
+  // Write DOT header
+  out << "digraph geometry {\n"
+      << "  rankdir=TB;\n"
+      << "  label=\"" << dot_escape(title) << "\";\n"
+      << "  labelloc=t;\n"
+      << "  node [shape=box, style=filled, fontsize=10];\n\n";
+
+  // Nodes (one per unique logical volume)
+  for (const auto* vol : volumes) {
+    int         count = vol_count.count(const_cast<TGeoVolume*>(vol))
+                          ? vol_count.at(const_cast<TGeoVolume*>(vol)) : 1;
+    std::string color = placement_color(count);
+    std::string label = dot_escape(vol->GetName());
+    if (count > 1) label += "\\n(" + std::to_string(count) + "x)";  // x for multiplicity
+    out << "  " << dot_id(vol)
+        << " [label=\"" << label << "\""
+        << ", fillcolor=\"" << color << "\""
+        << "];\n";
+  }
+  out << "\n";
+
+  // Edges (one per unique logical parent→child pair)
+  // Label shows children per parent instance (logical multiplicity)
+  for (auto& [pair, total] : edge_total) {
+    auto [parent, child] = pair;
+    int per_parent = vol_count.count(parent) && vol_count.at(parent) > 0
+                       ? (total + vol_count.at(parent) - 1) / vol_count.at(parent) : total;
+    out << "  " << dot_id(parent) << " -> " << dot_id(child);
+    if (per_parent > 1) out << " [label=\"" << per_parent << "x\"]";
+    out << ";\n";
+  }
+
+  out << "}\n";
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+template <typename T>
+void print_usage(T cli, const char* argv0) {
+  std::cout << "Usage:\n"     << usage_lines(cli, argv0)
+            << "\nOptions:\n" << documentation(cli) << '\n';
+}
+
+dot_settings cmdline_settings(int argc, char* argv[]) {
+  dot_settings s;
+
+  auto listMode = "list mode:" % (
+    command("list").set(s.selected, dot_mode::list)
+      % "Show full geometry tree from world volume"
+  );
+
+  // "part" subcommand may be repeated for multiple subtrees
+  auto partMode = "part mode:" % repeatable(
+    command("part").set(s.selected, dot_mode::part)
+      % "Show subtree(s) rooted at named volume(s)",
+    repeatable(
+      option("-l", "--level").set(s.level_set) & value("level", s.part_level)
+        % "Maximum depth for this part",
+      value("name")([&](const std::string& p) {
+        if (!s.level_set) s.part_level = s.default_level;
+        s.part_name_levels[p] = s.part_level;
+        s.level_set = false;
+      }) % "Volume name (must be child of world)"
+    )
+  );
+
+  auto lastOpt = "options:" % (
+    option("-h", "--help").set(s.selected, dot_mode::help) % "show help",
+    option("-d", "--depth") & integer("depth", s.default_level)
+      % "Maximum depth for full-tree mode (default: 2)",
+    option("-o", "--output") & value("out", s.outfile)
+      % "Output file base name (default: geometry)",
+    value("file", s.infile).if_missing([] {
+      std::cerr << "Error: input XML file required\n";
+    }) % "DD4hep compact XML file"
+  );
+
+  auto helpMode = command("help").set(s.selected, dot_mode::help);
+
+  auto cli = (helpMode | (partMode | listMode, lastOpt));
+
+  assert(cli.flags_are_prefix_free());
+  auto res = parse(argc, argv, cli);
+
+  if (s.selected == dot_mode::help) {
+    print_usage(cli, argv[0]);
+    return s;
+  }
+  if (res.any_error()) {
+    s.success = false;
+    print_usage(cli, argv[0]);
+    return s;
+  }
+  s.success = true;
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char* argv[]) {
+  dot_settings s = cmdline_settings(argc, argv);
+  if (!s.success) return 1;
+  if (s.selected == dot_mode::help) return 0;
+
+  if (!fs::exists(s.infile)) {
+    std::cerr << "File not found: " << s.infile << "\n";
+    return 1;
+  }
+
+  // Suppress DD4hep/ROOT noise
+  dd4hep::setPrintLevel(dd4hep::WARNING);
+  gErrorIgnoreLevel = kWarning;
+
+  dd4hep::Detector& detector = dd4hep::Detector::getInstance();
+  detector.fromCompact(s.infile);
+
+  TGeoManager* geo = gGeoManager;
+  if (!geo || !geo->GetTopVolume()) {
+    std::cerr << "Failed to load geometry from " << s.infile << "\n";
+    return 1;
+  }
+
+  std::string dotfile = s.outfile + ".dot";
+  std::ofstream out(dotfile);
+  if (!out) {
+    std::cerr << "Cannot open output file: " << dotfile << "\n";
+    return 1;
+  }
+
+  std::string title = fs::path(s.infile).stem().string();
+
+  if (s.selected == dot_mode::part) {
+    write_dot(out, geo, s.part_name_levels, -1, title);
+  } else {
+    // list mode: use default_level
+    write_dot(out, geo, {}, s.default_level, title);
+  }
+
+  out.close();
+  std::cout << "DOT file written: " << dotfile << "\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds `npdet_to_dot`, a new tool that traverses a DD4hep/TGeo geometry and writes a [Graphviz](https://graphviz.org/) DOT file representing the **logical volume tree**.

### Key features

- **One node per unique `TGeoVolume*`** — logical volume reuse is immediately visible: a volume placed N times appears as a single node, not N duplicated subtrees.
- **Color-coded placement count** in the traversed subtree:
  | Color | Placements |
  |---|---|
  | gray | 1 (unique placement) |
  | lemonchiffon | 2–9 |
  | lightgreen | 10–99 |
  | skyblue | 100+ |
- **Edge labels** show the per-parent logical multiplicity (how many times each child is placed in one instance of its parent).
- **`list` mode**: full tree from the world volume to a given depth (`-d`).
- **`part` mode**: one or more named subtrees, each with its own depth (`-l`), matching `npdet_to_step` CLI conventions.

### Usage

```bash
# Full tree to depth 3
npdet_to_dot list -d 3 -o epic_dirc_only epic_dirc_only.xml

# Two selected subtrees
npdet_to_dot part -l 3 DIRC part -l 3 DRICH -o epic_partial epic_craterlake.xml

# Convert to SVG
dot -Tsvg epic_dirc_only.dot -o epic_dirc_only.svg
```

### Example output (epic_dirc_only, depth 2)

```dot
digraph geometry {
  rankdir=TB;
  label="epic_dirc_only";
  node [shape=box, style=filled, fontsize=10];

  v... [label="world_volume", fillcolor="#d3d3d3"];
  v... [label="DIRC", fillcolor="#d3d3d3"];
  v... [label="DIRCSupport\n(12x)", fillcolor="#90ee90"];
  v... [label="DIRCModule\n(12x)", fillcolor="#90ee90"];

  v... -> v...;
  v... -> v... [label="12x"];
  v... -> v... [label="12x"];
}
```

### CI

Adds `.github/workflows/convert-to-dot.yml` called from `linux-eic-shell.yml`, running `npdet_to_dot list -d 3` on the same 6 detector configurations as the STEP export, then converting to SVG with `graphviz` and uploading both `.dot` and `.svg` as artifacts.