### PR TITLE
fix: use unique_ptr for TGeoPgon mesh vertex buffer in OCC_SimpleShape

### DIFF
--- a/src/geocad/src/TGeoToOCC.cxx
+++ b/src/geocad/src/TGeoToOCC.cxx
@@ -47,6 +47,7 @@ A log file is created in `/tmp/TGeoCad.log`
 
 #include "TGeoToOCC.h"
 #include <fstream>
+#include <memory>
 
 
 //Cascade
@@ -182,9 +183,9 @@ TopoDS_Shape TGeoToOCC::OCC_SimpleShape(TGeoShape *TG_Shape)
    } else if(TG_Shape->IsA()==TGeoPgon::Class()) {
       TGeoPgon* TG_Pgon=(TGeoPgon*)TG_Shape;
       Int_t numpoints=TG_Pgon->GetNmeshVertices();
-      Double_t *p = new Double_t[3*numpoints];
-      TG_Pgon->SetPoints(p);
-      return OCC_Pgon(TG_Pgon->GetNsegments(),TG_Pgon->GetNz(),p,TG_Pgon->GetPhi1(),TG_Pgon->GetDphi(),numpoints*3);
+      std::unique_ptr<Double_t[]> p(new Double_t[3*numpoints]);
+      TG_Pgon->SetPoints(p.get());
+      return OCC_Pgon(TG_Pgon->GetNsegments(),TG_Pgon->GetNz(),p.get(),TG_Pgon->GetPhi1(),TG_Pgon->GetDphi(),numpoints*3);
    } else if(TG_Shape->IsA()==TGeoHype::Class()) {
       TGeoHype* TG_Hype=(TGeoHype*)TG_Shape;
       return OCC_Hype(TG_Hype->GetRmin(), TG_Hype->GetRmax(), TG_Hype->GetStIn(), TG_Hype->GetStOut(),TG_Hype->GetDz());


### PR DESCRIPTION
## Problem

In `TGeoToOCC::OCC_SimpleShape`, the `TGeoPgon` branch allocates a heap buffer for mesh vertex data but never frees it:

```cpp
Double_t *p = new Double_t[3*numpoints];
TG_Pgon->SetPoints(p);
return OCC_Pgon(..., p, ...);   // p is never deleted
```

`OCC_Pgon` reads from `p` but does not store or free it.  This leaks the buffer on every call — detected by ASAN/LSAN in the epic STEP-export CI step:

```
Direct leak of 54624 byte(s) in 11 object(s) allocated from:
    #0 ... in operator new[](unsigned long)
    #1 ... in TGeoToOCC::OCC_SimpleShape(TGeoShape*)
```

Ref: https://github.com/eic/epic/actions/runs/26413319067/job/77753658285?pr=865

## Fix

Replace the raw `Double_t*` with `std::unique_ptr<Double_t[]>` so the buffer is automatically freed when `OCC_SimpleShape` returns.