### PR TITLE
feat: show assembly volumes with dashed border in npdet_to_dot

### DIFF
--- a/src/tools/src/npdet_to_dot.cxx
+++ b/src/tools/src/npdet_to_dot.cxx
@@ -10,6 +10,9 @@
 //   lightgreen  - placed 10-99 times
 //   skyblue     - placed 100+ times
 //
+// Assembly volumes (TGeoVolumeAssembly) are drawn with a dashed border to
+// distinguish them from regular encapsulating volumes.
+//
 // Edges connect parent to child logical volume and are labelled with the
 // number of child instances per parent instance (the logical multiplicity).
 
@@ -157,9 +160,12 @@ void write_dot(std::ostream& out, TGeoManager* geo,
     std::string color = placement_color(count);
     std::string label = dot_escape(vol->GetName());
     if (count > 1) label += "\\n(" + std::to_string(count) + "x)";  // x for multiplicity
+    // Assembly volumes get a dashed border to visually distinguish them
+    std::string style = vol->IsAssembly() ? "filled,dashed" : "filled";
     out << "  " << dot_id(vol)
         << " [label=\"" << label << "\""
         << ", fillcolor=\"" << color << "\""
+        << ", style=\"" << style << "\""
         << "];\n";
   }
   out << "\n";


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

The `npdet_to_dot` tool previously rendered all volumes identically regardless of their type. This PR makes assembly volumes (`TGeoVolumeAssembly`) render with a **dashed box outline**, visually distinguishing them from regular encapsulating volumes (solid border).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.