### PR TITLE
fix: handle world volume as requested part in npdet_to_dot

### DIFF
--- a/src/tools/src/npdet_to_dot.cxx
+++ b/src/tools/src/npdet_to_dot.cxx
@@ -217,7 +217,7 @@ dot_settings cmdline_settings(int argc, char* argv[]) {
         if (!s.level_set) s.part_level = s.default_level;
         s.part_name_levels[p] = s.part_level;
         s.level_set = false;
-      }) % "Volume name (must be child of world)"
+      }) % "Volume name (must be child of world, or the world volume itself)"
     )
   );
 

--- a/src/tools/src/npdet_to_dot.cxx
+++ b/src/tools/src/npdet_to_dot.cxx
@@ -106,6 +106,16 @@ void write_dot(std::ostream& out, TGeoManager* geo,
   bool        found_in_level_1 = !part_mode;
   std::string matched_part;
 
+  // If the world volume itself is among the requested parts, all level-1
+  // children fall within that subtree.
+  std::string world_name_match;
+  for (auto& [name, _] : part_name_levels) {
+    if (std::string(world->GetName()) == name) {
+      world_name_match = name;
+      break;
+    }
+  }
+
   TGeoIterator it(world);
   TGeoNode*    currentNode = nullptr;
   it.SetType(0);
@@ -124,6 +134,11 @@ void write_dot(std::ostream& out, TGeoManager* geo,
           matched_part     = name;
           break;
         }
+      }
+      // If the world volume itself was requested, every level-1 child qualifies.
+      if (!found_in_level_1 && !world_name_match.empty()) {
+        found_in_level_1 = true;
+        matched_part     = world_name_match;
       }
     }
     if (!found_in_level_1) { it.Skip(); continue; }

--- a/src/tools/src/npdet_to_dot.cxx
+++ b/src/tools/src/npdet_to_dot.cxx
@@ -108,13 +108,8 @@ void write_dot(std::ostream& out, TGeoManager* geo,
 
   // If the world volume itself is among the requested parts, all level-1
   // children fall within that subtree.
-  std::string world_name_match;
-  for (auto& [name, _] : part_name_levels) {
-    if (std::string(world->GetName()) == name) {
-      world_name_match = name;
-      break;
-    }
-  }
+  auto world_it = part_name_levels.find(world->GetName());
+  std::string world_name_match = (world_it != part_name_levels.end()) ? world_it->first : "";
 
   TGeoIterator it(world);
   TGeoNode*    currentNode = nullptr;


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

When the world volume name is passed as a part filter to `npdet_to_dot`, all level-1 children should qualify as being within that subtree. Previously the traversal logic only matched level-1 nodes against the requested part names, so specifying the world volume name produced an empty graph. This fix pre-checks whether the world volume itself is among the requested parts and, if so, marks every level-1 child as matching.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

GitHub Copilot was used to create the commit and open this PR.