### PR TITLE
feat: enable G4HepEm for EcalBarrelScFiLayerRegion

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -31,7 +31,13 @@ if __name__ == "__main__":
   def setupHepEm(kernel):
     from DDG4 import PhysicsList
     seq = kernel.physicsList()
-    hepem = PhysicsList(kernel, 'Geant4HepEmTrackingPhysics/HepEmPhysics')
+    try:
+      hepem = PhysicsList(kernel, 'Geant4HepEmTrackingPhysics/HepEmPhysics')
+    except Exception as e:
+      raise RuntimeError(
+        "Geant4HepEmTrackingPhysics plugin is not available. Build DD4hep with "
+        "DD4HEP_USE_G4HEPEM=ON and ensure DDG4HepEm is on LD_LIBRARY_PATH."
+      ) from e
     hepem.WoodcockRegions = ['EcalBarrelScFiLayerRegion']
     hepem.enableUI()
     seq.adopt(hepem)

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -27,6 +27,16 @@ if __name__ == "__main__":
   # https://github.com/AIDASoft/DD4hep/pull/1376
   RUNNER.parseOptions()
 
+  # Ensure that G4HepEm vectorized EM physics is always loaded
+  def setupHepEm(kernel):
+    from DDG4 import PhysicsList
+    seq = kernel.physicsList()
+    hepem = PhysicsList(kernel, 'Geant4HepEmTrackingPhysics/HepEmPhysics')
+    hepem.WoodcockRegions = ['EcalBarrelScFiLayerRegion']
+    hepem.enableUI()
+    seq.adopt(hepem)
+  RUNNER.physics.setupUserPhysics(setupHepEm)
+
   # Ensure that Cerenkov and optical physics are always loaded
   def setupCerenkov(kernel):
     from DDG4 import PhysicsList


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR enables G4HepEm physics in the EcalBarrelScFiLayers region (excludes the imaging layers). This removes most of the gamma simulation load.

Needs:
- [x] https://github.com/AIDASoft/DD4hep/pull/1641

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Optimization (issue: gammas in EcalBarrelScFiLayers are dominant navigation cost)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

We now use Woodcock tracking for gammas in the EcalBarrelScFiLayers.
