### PR TITLE
Allow setting userParticleHandler to Geant4TCUserParticleHandler

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -20,6 +20,8 @@ if __name__ == "__main__":
 
   RUNNER = DD4hepSimulation()
 
+  RUNNER.part.userParticleHandler = "Geant4TVEicParticleHandler"
+
   # Parse remaining options (command line and steering file override above)
   # This is done before updating the settings to workaround issue reported in
   # https://github.com/AIDASoft/DD4hep/pull/1376
@@ -70,10 +72,6 @@ if __name__ == "__main__":
     _orig_setupUserParticleHandler(self, part, kernel, DDG4)
 
   _PH.setupUserParticleHandler = _setupUserParticleHandler
-
-  # To allow users set different handlers (other that default at least)
-  if RUNNER.part.userParticleHandler == "Geant4TCUserParticleHandler":
-    RUNNER.part.userParticleHandler = "Geant4TVEicParticleHandler"
 
   # Disable warnings for unstable resonances with off-shell mass
   if hasattr(RUNNER.physics, "ESeverity"):


### PR DESCRIPTION
This is a hotfix. The issue is that we would like to enable alternative workaround from:
https://github.com/eic/npsim/blob/fc871fc76d8548d526780e18b396519555b07660/src/plugins/src/Geant4TVEicParticleHandler.cxx#L146-L148
and currently it doesn't work