### PR TITLE
fix: add DIRC {lens,prism}_vol to Cherenkov QE suppression

### DIFF
--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
       "parameter": {
         "LambdaMin": "180*nm",
         "LambdaMax": "678*nm",
-        "LogicalVolume": "(bar_vol|Envelope_lens_vol|Envelop_trap_vol)",
+        "LogicalVolume": "(Envelope_lens_vol|Envelop_trap_vol)",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,
           17.7, 18.1, 18.8, 19.3, 19.8, 20.6, 21.4, 22.4, 23.1, 23.6, 24.1, 24.2, 24.6, 24.8, 25.2,

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
       "parameter": {
         "LambdaMin": "180*nm",
         "LambdaMax": "678*nm",
-        "LogicalVolume": "(bar_vol|Envelope_lens_vol|Envelop_trap_vol)",
+        "LogicalVolume": "(bar_vol|lens_layer\d_vol|prism_vol)",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,
           17.7, 18.1, 18.8, 19.3, 19.8, 20.6, 21.4, 22.4, 23.1, 23.6, 24.1, 24.2, 24.6, 24.8, 25.2,

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
       "parameter": {
         "LambdaMin": "180*nm",
         "LambdaMax": "678*nm",
-        "LogicalVolume": "(bar_vol|lens_layer\d_vol|prism_vol)",
+        "Region": "DIRCRegion",
+        "LogicalVolume": "(bar_vol|glue_vol|lens_layer\d_vol|prism_vol|mcp_vol|Envelope_box_vol|Envelope_trap_vol)",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,
           17.7, 18.1, 18.8, 19.3, 19.8, 20.6, 21.4, 22.4, 23.1, 23.6, 24.1, 24.2, 24.6, 24.8, 25.2,

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
       "parameter": {
         "LambdaMin": "180*nm",
         "LambdaMax": "678*nm",
-        "LogicalVolume": "bar_vol",
+        "LogicalVolume": "bar_vol|Envelope_lens_vol|Envelop_trap_vol",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,
           17.7, 18.1, 18.8, 19.3, 19.8, 20.6, 21.4, 22.4, 23.1, 23.6, 24.1, 24.2, 24.6, 24.8, 25.2,

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
       "parameter": {
         "LambdaMin": "180*nm",
         "LambdaMax": "678*nm",
-        "LogicalVolume": "bar_vol|Envelope_lens_vol|Envelop_trap_vol",
+        "LogicalVolume": "(bar_vol|Envelope_lens_vol|Envelop_trap_vol)",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,
           17.7, 18.1, 18.8, 19.3, 19.8, 20.6, 21.4, 22.4, 23.1, 23.6, 24.1, 24.2, 24.6, 24.8, 25.2,

--- a/src/dd4pod/python/npsim.py
+++ b/src/dd4pod/python/npsim.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
       "parameter": {
         "LambdaMin": "180*nm",
         "LambdaMax": "678*nm",
-        "LogicalVolume": "(Envelope_lens_vol|Envelop_trap_vol)",
+        "LogicalVolume": "(bar_vol|Envelope_lens_vol|Envelop_trap_vol)",
         "Efficiency": [e/100. for e in [
           0,    0,    14.0, 14.8, 14.5, 14.9, 14.4, 14.2, 13.9, 14.6, 15.2, 15.7, 16.4, 16.9, 17.5,
           17.7, 18.1, 18.8, 19.3, 19.8, 20.6, 21.4, 22.4, 23.1, 23.6, 24.1, 24.2, 24.6, 24.8, 25.2,


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR also adds the `Envelope_{lens,trap}_vol` pattern to the Cherenkov QE suppression volume list. This ensures that background tracks through the lens and expansion volume are also suppressed with QE.

Needs:
- [x] #76
- [x] https://github.com/eic/epic/pull/1130

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: backgrounds through expansion volume overrepresented)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
