### PR TITLE
fix: require workflow_conclusion 'completed' for previous artifact

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -123,7 +123,7 @@ jobs:
           path: ref/
           name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
           workflow: .github/workflows/linux-eic-shell.yml
-          workflow_conclusion: ""
+          workflow_conclusion: "completed"
           if_no_artifact_found: warn
       - name: Compare to previous artifacts
         uses: eic/run-cvmfs-osg-eic-shell@main
@@ -197,7 +197,7 @@ jobs:
           path: ref/
           name: sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root
           workflow: .github/workflows/linux-eic-shell.yml
-          workflow_conclusion: ""
+          workflow_conclusion: "completed"
           if_no_artifact_found: warn
       - name: Compare to previous artifacts
         uses: eic/run-cvmfs-osg-eic-shell@main


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that artifact downloads only occur if the referenced workflow has fully completed, improving the reliability of dependent steps.

- Workflow configuration improvement:
  * In `.github/workflows/linux-eic-shell.yml`, set the `workflow_conclusion` parameter to `"completed"` for artifact download steps, instead of an empty string, in both relevant jobs. [[1]](diffhunk://#diff-1979202099e4ebc6d02b6dbd6ade89a6d9895896cd610bb3829b3b84f5239b38L126-R126) [[2]](diffhunk://#diff-1979202099e4ebc6d02b6dbd6ade89a6d9895896cd610bb3829b3b84f5239b38L200-R200)

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: avoid trying to pull artifacts from workflows that are still running)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
