### PR TITLE
feat: print unsuppressed optical photons

### DIFF
--- a/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
+++ b/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
@@ -42,7 +42,7 @@ namespace dd4hep {
       };
       /// Default destructor
       virtual ~OpticalPhotonEfficiencyStackingAction() {
-        printout(INFO, name(), "Suppressed %d of %d photons in lv regex %s or region regex %s",
+        printout(INFO, name(), "Suppressed %zu of %zu photons in lv regex %s or region regex %s",
           m_killed_photons, m_total_photons, m_logical_volume.c_str(), m_region.c_str());
         for (const auto& [lv, count] : m_unsuppressed_photons) {
           printout(INFO, name(), "Unsuppressed photons in lv %s: %zu", lv.c_str(), count);

--- a/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
+++ b/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
@@ -42,8 +42,11 @@ namespace dd4hep {
       };
       /// Default destructor
       virtual ~OpticalPhotonEfficiencyStackingAction() {
-        printout(DEBUG, name(), "Suppressed %d of %d photons in lv regex %s or region regex %s",
+        printout(INFO, name(), "Suppressed %d of %d photons in lv regex %s or region regex %s",
           m_killed_photons, m_total_photons, m_logical_volume.c_str(), m_region.c_str());
+        for (const auto& [lv, count] : m_unsuppressed_photons) {
+          printout(INFO, name(), "Unsuppressed photons in lv %s: %zu", lv.c_str(), count);
+        }
         printout(DEBUG, name(), "lambda range: [%f,%f] nm",
           m_lambda_min / CLHEP::nm, m_lambda_max / CLHEP::nm);
         std::ostringstream oss_efficiency;
@@ -126,6 +129,7 @@ namespace dd4hep {
               printout(VERBOSE, name(), "outside lambda range [%f,%f] nm", m_lambda_min / CLHEP::nm, m_lambda_max / CLHEP::nm);
             }
           } else {
+            m_unsuppressed_photons[volume_name]++;
             printout(VERBOSE, name(), "no QE match for lv %s against %s or region %s against %s",
               volume_name.c_str(), m_logical_volume.c_str(), region_name.c_str(), m_region.c_str());
           }
@@ -156,6 +160,7 @@ namespace dd4hep {
       std::string m_cached_logical_volume, m_cached_region;
       std::optional<std::regex> m_logical_volume_regex, m_region_regex;
       std::size_t m_total_photons{0}, m_killed_photons{0};
+      std::map<std::string, std::size_t> m_unsuppressed_photons;
     };
   }    // End namespace sim
 }      // End namespace dd4hep

--- a/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
+++ b/src/plugins/include/npdet/OpticalPhotonEfficiencyStackingAction.h
@@ -20,6 +20,7 @@
 #include "G4Region.hh"
 #include "G4Track.hh"
 
+#include <map>
 #include <optional>
 #include <regex>
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR expands the OpticalPhotonEfficiencyStackingAction plugin's destructor printout with a listing of volumes with unsuppressed optical photons. This can be used to identify which volumes may still need to be added to suppression.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: additional diagnostics output)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
