### PR TITLE
fix(ci): run npsim with `--random.enableEventSeed`

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -104,6 +104,7 @@ jobs:
             export LD_LIBRARY_PATH=$PWD/install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
             npsim --compactFile ${DETECTOR_PATH}/${{ matrix.detector_config }}.xml -G \
               --random.seed 1 \
+              --random.enableEventSeed \
               --gun.particle "${{ matrix.particle }}-" \
               --gun.momentumMin "1*GeV" \
               --gun.momentumMax "20*GeV" \
@@ -182,6 +183,7 @@ jobs:
               -N 100 \
               --inputFiles ${url} \
               --random.seed 1 \
+              --random.enableEventSeed \
               --outputFile sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root \
               -v WARNING
       - name: Upload ROOT output


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds `--random.enableEventSeed` to the npsim CI tests to ensure we end up simulating the same events even when the internal event random number consumption changes. Mostly aspirational until we pick up https://github.com/AIDASoft/DD4hep/pull/1617 (at least for gun)...

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: ensure events are reproducible)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
