### PR TITLE
hotfix: pass sanitizer options explicitly to reusable workflows

### DIFF
--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -5,3 +5,4 @@ leak:libCling.so
 leak:libCore.so
 leak:TCollection_AsciiString::reallocate
 leak:TPrsStd_DriverTable::Get
+leak:Standard::Allocate

--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -3,3 +3,5 @@ leak:dd4hep::DetElementObject::clone
 leak:dd4hep::VisAttr::VisAttr
 leak:libCling.so
 leak:libCore.so
+leak:TCollection_AsciiString::reallocate
+leak:TPrsStd_DriverTable::Get

--- a/.github/lsan.supp
+++ b/.github/lsan.supp
@@ -3,6 +3,7 @@ leak:dd4hep::DetElementObject::clone
 leak:dd4hep::VisAttr::VisAttr
 leak:libCling.so
 leak:libCore.so
+leak:TGeoTessellated::BuildBVH
 leak:TCollection_AsciiString::reallocate
 leak:TPrsStd_DriverTable::Get
 leak:Standard::Allocate

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -24,19 +24,19 @@ on:
       lsan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/lsan.supp
+        default: suppressions=.github/lsan.supp
       asan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+        default: suppressions=.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
       ubsan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+        default: suppressions=.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
       tsan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/tsan.supp
+        default: suppressions=.github/tsan.supp
 
 permissions:
   contents: read

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -21,6 +21,22 @@ on:
         required: false
         type: string
         default: /opt/detector/epic-main/bin/thisepic.sh
+      lsan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/lsan.supp
+      asan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+      ubsan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+      tsan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/tsan.supp
 
 permissions:
   contents: read
@@ -42,6 +58,11 @@ jobs:
         run: tar -xaf install.tar.zst
       - uses: cvmfs-contrib/github-action-cvmfs@10197e000cc0add8e54ac4fb73d3ed44e2de72b4  # v5
       - uses: eic/run-cvmfs-osg-eic-shell@7a90477d48c1affe69ce8d4b8a3cb1d945c2a7c2  # main
+        env:
+          LSAN_OPTIONS: ${{ inputs.lsan_options }}
+          ASAN_OPTIONS: ${{ inputs.asan_options }}
+          UBSAN_OPTIONS: ${{ inputs.ubsan_options }}
+          TSAN_OPTIONS: ${{ inputs.tsan_options }}
         with:
           organization: "${{ inputs.organization }}"
           platform-release: "${{ inputs.platform-release }}"

--- a/.github/workflows/convert-to-dot.yml
+++ b/.github/workflows/convert-to-dot.yml
@@ -68,6 +68,11 @@ jobs:
           platform-release: "${{ inputs.platform-release }}"
           setup: ${{ inputs.epic_setup_script }}
           run: |
+            for option_var in LSAN_OPTIONS ASAN_OPTIONS UBSAN_OPTIONS TSAN_OPTIONS ; do
+              option_value="${!option_var}"
+              option_value="${option_value/suppressions=.github/suppressions=${GITHUB_WORKSPACE}/.github}"
+              export "${option_var}=${option_value}"
+            done
             export PATH=$PWD/install/bin${PATH:+:$PATH}
             export LD_LIBRARY_PATH=$PWD/install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
             npdet_to_dot list -d 3 -o ${{matrix.detector_config}} $DETECTOR_PATH/${{matrix.detector_config}}.xml

--- a/.github/workflows/convert-to-step.yml
+++ b/.github/workflows/convert-to-step.yml
@@ -24,19 +24,19 @@ on:
       lsan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/lsan.supp
+        default: suppressions=.github/lsan.supp
       asan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+        default: suppressions=.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
       ubsan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+        default: suppressions=.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
       tsan_options:
         required: false
         type: string
-        default: suppressions=${{ github.workspace }}/.github/tsan.supp
+        default: suppressions=.github/tsan.supp
 
 permissions:
   contents: read

--- a/.github/workflows/convert-to-step.yml
+++ b/.github/workflows/convert-to-step.yml
@@ -68,6 +68,11 @@ jobs:
           platform-release: "${{ inputs.platform-release }}"
           setup: ${{ inputs.epic_setup_script }}
           run: |
+            for option_var in LSAN_OPTIONS ASAN_OPTIONS UBSAN_OPTIONS TSAN_OPTIONS ; do
+              option_value="${!option_var}"
+              option_value="${option_value/suppressions=.github/suppressions=${GITHUB_WORKSPACE}/.github}"
+              export "${option_var}=${option_value}"
+            done
             export PATH=$PWD/install/bin${PATH:+:$PATH}
             export LD_LIBRARY_PATH=$PWD/install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
             # For some reason npdet_to_step really wants a space in IFS

--- a/.github/workflows/convert-to-step.yml
+++ b/.github/workflows/convert-to-step.yml
@@ -21,6 +21,22 @@ on:
         required: false
         type: string
         default: /opt/detector/epic-main/bin/thisepic.sh
+      lsan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/lsan.supp
+      asan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+      ubsan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+      tsan_options:
+        required: false
+        type: string
+        default: suppressions=${{ github.workspace }}/.github/tsan.supp
 
 permissions:
   contents: read
@@ -42,6 +58,11 @@ jobs:
         run: tar -xaf install.tar.zst
       - uses: cvmfs-contrib/github-action-cvmfs@v5
       - uses: eic/run-cvmfs-osg-eic-shell@main
+        env:
+          LSAN_OPTIONS: ${{ inputs.lsan_options }}
+          ASAN_OPTIONS: ${{ inputs.asan_options }}
+          UBSAN_OPTIONS: ${{ inputs.ubsan_options }}
+          TSAN_OPTIONS: ${{ inputs.tsan_options }}
         with:
           organization: "${{ inputs.organization }}"
           platform-release: "${{ inputs.platform-release }}"

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -45,10 +45,10 @@ env:
   platform: ${{ inputs.platform || 'eic_xl' }}
   release: ${{ inputs.release || 'nightly' }}
   detector_version: ${{ inputs.detector_version || 'main' }}
-  ASAN_OPTIONS: suppressions=.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
-  LSAN_OPTIONS: suppressions=.github/lsan.supp
-  UBSAN_OPTIONS: suppressions=.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
-  TSAN_OPTIONS: suppressions=.github/tsan.supp
+  ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+  LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
+  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+  TSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/tsan.supp
 
 jobs:
   build:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -237,10 +237,10 @@ jobs:
       install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
-      lsan_options: ${{ env.LSAN_OPTIONS }}
-      asan_options: ${{ env.ASAN_OPTIONS }}
-      ubsan_options: ${{ env.UBSAN_OPTIONS }}
-      tsan_options: ${{ env.TSAN_OPTIONS }}
+      lsan_options: suppressions=${{ github.workspace }}/.github/lsan.supp
+      asan_options: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+      ubsan_options: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+      tsan_options: suppressions=${{ github.workspace }}/.github/tsan.supp
 
   convert-to-dot:
     needs:
@@ -251,10 +251,10 @@ jobs:
       install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
-      lsan_options: ${{ env.LSAN_OPTIONS }}
-      asan_options: ${{ env.ASAN_OPTIONS }}
-      ubsan_options: ${{ env.UBSAN_OPTIONS }}
-      tsan_options: ${{ env.TSAN_OPTIONS }}
+      lsan_options: suppressions=${{ github.workspace }}/.github/lsan.supp
+      asan_options: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+      ubsan_options: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+      tsan_options: suppressions=${{ github.workspace }}/.github/tsan.supp
 
   merge-npsim-capybara:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -237,6 +237,10 @@ jobs:
       install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
+      lsan_options: ${{ env.LSAN_OPTIONS }}
+      asan_options: ${{ env.ASAN_OPTIONS }}
+      ubsan_options: ${{ env.UBSAN_OPTIONS }}
+      tsan_options: ${{ env.TSAN_OPTIONS }}
 
   convert-to-dot:
     needs:
@@ -247,6 +251,10 @@ jobs:
       install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
+      lsan_options: ${{ env.LSAN_OPTIONS }}
+      asan_options: ${{ env.ASAN_OPTIONS }}
+      ubsan_options: ${{ env.UBSAN_OPTIONS }}
+      tsan_options: ${{ env.TSAN_OPTIONS }}
 
   merge-npsim-capybara:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -45,10 +45,10 @@ env:
   platform: ${{ inputs.platform || 'eic_xl' }}
   release: ${{ inputs.release || 'nightly' }}
   detector_version: ${{ inputs.detector_version || 'main' }}
-  ASAN_OPTIONS: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
-  LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
-  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
-  TSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/tsan.supp
+  ASAN_OPTIONS: suppressions=.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+  LSAN_OPTIONS: suppressions=.github/lsan.supp
+  UBSAN_OPTIONS: suppressions=.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+  TSAN_OPTIONS: suppressions=.github/tsan.supp
 
 jobs:
   build:
@@ -237,10 +237,10 @@ jobs:
       install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
-      lsan_options: suppressions=${{ github.workspace }}/.github/lsan.supp
-      asan_options: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
-      ubsan_options: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
-      tsan_options: suppressions=${{ github.workspace }}/.github/tsan.supp
+      lsan_options: suppressions=.github/lsan.supp
+      asan_options: suppressions=.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+      ubsan_options: suppressions=.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+      tsan_options: suppressions=.github/tsan.supp
 
   convert-to-dot:
     needs:
@@ -251,10 +251,10 @@ jobs:
       install_artifact_name: install-g++-eic-shell-Release-${{ inputs.platform || 'eic_xl' }}-${{ inputs.release || 'nightly' }}
       organization: "${{ inputs.organization || 'eicweb' }}"
       platform-release: "${{ inputs.platform || 'eic_xl' }}:${{ inputs.release || 'nightly' }}"
-      lsan_options: suppressions=${{ github.workspace }}/.github/lsan.supp
-      asan_options: suppressions=${{ github.workspace }}/.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
-      ubsan_options: suppressions=${{ github.workspace }}/.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
-      tsan_options: suppressions=${{ github.workspace }}/.github/tsan.supp
+      lsan_options: suppressions=.github/lsan.supp
+      asan_options: suppressions=.github/asan.supp:malloc_context_size=20:detect_leaks=1:verify_asan_link_order=0:detect_stack_use_after_return=1:detect_odr_violation=1:new_delete_type_mismatch=0:intercept_tls_get_addr=0
+      ubsan_options: suppressions=.github/ubsan.supp:print_stacktrace=1:silence_unsigned_overflow=1:report_error_type=1
+      tsan_options: suppressions=.github/tsan.supp
 
   merge-npsim-capybara:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit sanitizer option workflow_call inputs to convert-to-step and convert-to-dot reusable workflows
- wire LSAN_OPTIONS, ASAN_OPTIONS, UBSAN_OPTIONS, and TSAN_OPTIONS into eic/run-cvmfs-osg-eic-shell env in both reusable workflows
- pass sanitizer options explicitly from linux-eic-shell convert-to-step and convert-to-dot caller jobs

## Testing
- parsed modified workflow YAML files successfully with PyYAML syntax sanity check

## Notes
- no repository pull request template file was found under .github in this checkout